### PR TITLE
fix: memo에 memosID 안들어가는 문제 수정

### DIFF
--- a/backend/src/memo/memo.controller.ts
+++ b/backend/src/memo/memo.controller.ts
@@ -7,12 +7,10 @@ import { MemosController } from '../memos/memos.controller';
 @Controller('memo')
 export class MemoController {
     private readonly logger = new Logger(MemosController.name);
-
     constructor(private readonly memoService: MemoService) {}
-    // TODO: Memos ID가 필요한거 아닌가? @Post(':memosId')
+
     @Post()
     async createMemo(@Body() createMemoDto: CreateMemoDto) {
-        this.logger.log('------memo 생성(컨트롤러)');
         return await this.memoService.createMemo(createMemoDto);
     }
 

--- a/backend/src/memo/memo.service.ts
+++ b/backend/src/memo/memo.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Memo } from './memo.entity';
+import { Memos } from 'src/memos/memos.entity';
 import { Repository } from 'typeorm';
 import { CreateMemoDto } from './dto/create-memo.dto';
 import { UpdateMemoDto } from './dto/update-memo.dto';
@@ -8,12 +9,21 @@ import { UpdateMemoDto } from './dto/update-memo.dto';
 @Injectable()
 export class MemoService {
     constructor(
-        @InjectRepository(Memo)
-        private memoRepository: Repository<Memo>,
+        @InjectRepository(Memos) private readonly memosRepository: Repository<Memos>,
+        @InjectRepository(Memo) private readonly memoRepository: Repository<Memo>,
     ) {}
 
     async createMemo(createMemoDto: CreateMemoDto): Promise<Memo> {
-        const memo = this.memoRepository.create(createMemoDto);
+        const { memosId, ...rest } = createMemoDto;
+        const memos = await this.memosRepository.findOne({
+            where: { id: memosId },
+        });
+
+        const memo = this.memoRepository.create({
+            ...rest,
+            memos,
+        });
+
         return await this.memoRepository.save(memo);
     }
 


### PR DESCRIPTION
- memo create 부분에 다대일 관계이기 때문에 실제 연관된 엔티티 객체 할당 필요

## 🛰️ Issue Number
- #182 

## 🪐 작업 내용
- memo create 부분에 다대일 관계이기 때문에 실제 연관된 엔티티 객체 할당 필요
## 📚 Reference

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
